### PR TITLE
Use Drupal release (not source)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -183,7 +183,6 @@
             "php": "7.1.3"
         },
         "preferred-install": {
-            "drupal/core": "source",
             "va-gov/web": "source"
         }
     },


### PR DESCRIPTION
We can't actually keep this right now because DEMO is still on devshop and devshop is on a VPC that blocks the release download. But this will make testing PRs faster over here. 