### PR TITLE
Set unlimited memory limit for PHP cli to allow composer to run

### DIFF
--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -30,6 +30,8 @@ services:
         # BRD Environments are set to 1G, DevShop and Lando are -1 (unlimited).
         - echo "memory_limit = 1G" >> /usr/local/etc/php/conf.d/my-php.ini
         - echo "max_execution_time = 1200" >> /usr/local/etc/php/conf.d/my-php.ini
+        # Set unlimited memory limit for PHP cli to allow composer to run.
+        - echo "memory_limit = -1" >> /usr/local/etc/php/conf.d/php-cli.ini
 
         # .tugboat/.env.j2 Jinja2 template file support
         - apt-get install python3-apt python3-distutils python3


### PR DESCRIPTION
This allows composer to run without OOM errors.